### PR TITLE
fix(union-type-copy): fix typo in copy

### DIFF
--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -80,7 +80,7 @@ export class UnionType implements SchemaType {
     result.counter = this.counter;
     result.types = Object.entries(this.types).reduce(
       (partial: SchemaObject, [key, schema]) => {
-        return { partial, [key]: schema.copy() };
+        return { ...partial, [key]: schema.copy() };
       },
       {}
     );


### PR DESCRIPTION
adds a forgotten spread operator